### PR TITLE
add support for oku rss → json endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-# cards.cyberb.space
+# api.cyberb.space
 
-bespoke social media cards for [cyberb.space](https://cyberb.space)
+This is a monorepo for any personal APIs I want to expose. It is a mono repo because I'm cheap and don't want to pay more than $5 a month to support these little side projects.
+
+So far it includes: 
+1. bespoke social media cards for [cyberb.space](https://cyberb.space)
+2. an endpoint that turns [Oku Collection RSS feeds](https://oku.club/blog/oku-has-rss-feeds) into nice, useable API responses

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// Card Dimensions
 module.exports.IMAGE_HEIGHT = 360;
 module.exports.IMAGE_WIDTH = 720;
 
@@ -10,3 +11,6 @@ module.exports.AUTHOR_OFFSETS = { top: 40, left: 85 };
 module.exports.TITLE_OFFSETS = { top: 100, left: 130 };
 module.exports.SUMMARY_OFFSETS = { top: 160, left: 135 };
 module.exports.DATE_OFFSETS = { top: 280, left: 460 };
+
+// RSS processing
+module.exports.OKU_BASE_URL = 'https://oku.club/rss/collection/';

--- a/middleware/finalizeJSONResponse.js
+++ b/middleware/finalizeJSONResponse.js
@@ -1,0 +1,36 @@
+'use strict';
+
+function finalizeJSONResponse(req, res, next) {
+    const { parsedXML } = res.locals;
+    const rootChannelChildren = parsedXML['children'][0]['children'];
+
+    const bookList = rootChannelChildren
+        .filter((i) => i.name === 'item')
+        .map((i) => {
+            const fullBook = {}
+            i.children.forEach((book) => {
+                if (book.name === 'dc:creator') {
+                    fullBook.author = book.value;
+                } else {
+                    fullBook[book.name] = book.value;
+                }
+            });
+            return fullBook;
+        })
+
+    const finalizedJSON = {};
+    const nonBooks = rootChannelChildren.filter((i) => i.name !== 'item');
+    nonBooks.forEach((datum) => {
+        if (datum.name === 'atom:link') {
+            finalizedJSON['rss'] = datum.attributes.href;
+        } else {
+            finalizedJSON[datum.name] = datum.value;
+        }
+    });
+
+    finalizedJSON.items = bookList
+
+    res.send(finalizedJSON);
+}
+
+module.exports = finalizeJSONResponse;

--- a/middleware/processRSS.js
+++ b/middleware/processRSS.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const request = require('needle');
+const { OKU_BASE_URL } = require('../lib/constants');
+
+function processRSS(req, res, next) {
+    const rssID = req.params.collectionId; 
+    const url = OKU_BASE_URL + rssID;
+    
+    let XML;
+    request.get(url, (err, resp, body) => {
+        XML = body;
+        res.locals.parsedXML = XML
+        return next();
+    });
+}
+
+module.exports = processRSS;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.2",
+        "needle": "^3.0.0",
         "sharp": "^0.29.3"
       },
       "devDependencies": {
@@ -2118,6 +2119,35 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/needle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
+      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/needle/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -2588,6 +2618,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2736,9 +2771,9 @@
       ]
     },
     "node_modules/simple-get": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
-      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "funding": [
         {
           "type": "github",
@@ -4745,6 +4780,31 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "needle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
+      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -5085,6 +5145,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -5193,9 +5258,9 @@
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
-      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "requires": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cards.cyberb.space",
+  "name": "api.cyberb.space",
   "version": "0.0.1",
   "description": "little express app that makes pictures",
   "main": "server.js",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/riastrad/cards.cyberb.space.git"
+    "url": "git+https://github.com/riastrad/api.cyberb.space.git"
   },
   "keywords": [
     "api",
@@ -24,11 +24,12 @@
   "author": "@riastrad",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/riastrad/cards.cyberb.space/issues"
+    "url": "https://github.com/riastrad/api.cyberb.space/issues"
   },
-  "homepage": "https://github.com/riastrad/cards.cyberb.space#readme",
+  "homepage": "https://github.com/riastrad/api.cyberb.space#readme",
   "dependencies": {
     "express": "^4.17.2",
+    "needle": "^3.0.0",
     "sharp": "^0.29.3"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -3,9 +3,11 @@
 const express = require('express')
 const processParams = require('./middleware/processParams');
 const generateImage = require('./lib/generateImage');
+const processRSS = require('./middleware/processRSS');
+const finalizeJSONResponse = require('./middleware/finalizeJSONResponse');
 
 const server = express();
-const port = 3030;
+const port = process.env.SERVER_PORT || 3030;
 
 server.get('/', (req, res) => {
     res.send({ status: 'OK' });
@@ -16,7 +18,8 @@ server.use((req, res, next) => {
     return next();
 });
 
-server.get('/post.jpg', processParams, generateImage, (req, res) => {
+// card generator route
+server.get('/cards/post.jpg', processParams, generateImage, (req, res) => {
     if (res.locals.finalImage) {
         res.type('jpg');
         res.send(res.locals.finalImage);
@@ -24,6 +27,9 @@ server.get('/post.jpg', processParams, generateImage, (req, res) => {
         res.status(422).send('Unable to generate image');
     }
 });
+
+// rss feed converter route
+server.get('/oku/rss/collection/:collectionId', processRSS, finalizeJSONResponse);
 
 server.listen(port, () => {
     console.log(`Example app listening at http://localhost:${port}`)


### PR DESCRIPTION
This change turns the repo into a monorepo to hold any api idea I have. 

It also adds support for a new `/oku/rss/collection/:collectionId` endpoint, which is meant to provide a simple API for [Oku RSS feeds](https://oku.club/blog/oku-has-rss-feeds).
